### PR TITLE
Update Qt test versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt-version: ['5.9.2', '5.15.0', '6.2.0']
+        qt-version: ['5.9.2', '5.15.*', '6.5.*', '6.9.*']
         compiler-type: [gcc, clang]
     steps:
       - name: Checkout sources


### PR DESCRIPTION
- [x] Use latest 5.15.* version available
- [x] Replace 6.2.0 tests with 6.5.* latest version available
- [x] Add latest 6.9.* version available